### PR TITLE
ISON implementation

### DIFF
--- a/miniircd
+++ b/miniircd
@@ -221,6 +221,14 @@ class Client(object):
         def away_handler():
             pass
 
+        def ison_handler():
+            if len(arguments) < 1:
+                self.reply_461("ISON")
+                return
+            nicks = arguments
+            online = [n for n in nicks if server.get_client(n)]
+            self.reply("303 %s :%s" % (self.nickname, " ".join(online)))
+
         def join_handler():
             if len(arguments) < 1:
                 self.reply_461("JOIN")
@@ -500,6 +508,7 @@ class Client(object):
 
         handler_table = {
             "AWAY": away_handler,
+            "ISON": ison_handler,
             "JOIN": join_handler,
             "LIST": list_handler,
             "MODE": mode_handler,
@@ -820,3 +829,5 @@ def main(argv):
 
 
 main(sys.argv)
+
+# ex:et:sw=4:ts=4

--- a/test.py
+++ b/test.py
@@ -77,7 +77,7 @@ class ServerFixture(object):
         signal.alarm(1)  # Give the server 1 second to respond
         line = self.connections[nick].readline().rstrip()
         signal.alarm(0)  # Cancel the alarm
-        regexp = "^%s$" % regexp
+        regexp = ("^%s$" % regexp).replace(r"local\S+", socket.getfqdn())
         m = re.match(regexp, line)
         if m:
             return m
@@ -240,6 +240,15 @@ class TestBasicStuff(ServerFixture):
         self.send("lemur", "PART #fisk :boa")
         self.expect("lemur", r":lemur!lemur@127.0.0.1 PART #fisk :boa")
         self.expect("apa", r":lemur!lemur@127.0.0.1 PART #fisk :boa")
+
+    def test_ison(self):
+        self.connect("apa")
+        self.send("apa", "ISON apa lemur")
+        self.expect("apa", r":local\S+ 303 apa :apa")
+
+        self.connect("lemur")
+        self.send("apa", "ISON apa lemur")
+        self.expect("apa", r":local\S+ 303 apa :apa lemur")
 
 
 class TestTwoChannelsStuff(TwoClientsTwoChannelsFixture):


### PR DESCRIPTION
Hi jrosdahl,

I wrote this patch which enables us to use miniircd as a quickie IM solution internally.  Pidgin wouldn't let us add each other as buddies because ISON wasn't supported.

I added bits to the test suite for it, and also one other thing: on my Debian system, socket.getfqdn() actually returns "pitch", not "local"-anything, so I did a quick string-replace in expect to make that work.  A better way would probably modify those expects so that they could be prefixed with the results of getfqdn().  If you are interested in such a thing let me know...
