### PR TITLE
Removed needless setres[gu]id to allow --setuid to work with Python 2.7.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ Limitations
 Requirements
 ------------
 
-Python 2.5 or newer, Python 2.6 or newer when --ssl-pem-file is used, Python
-2.7 or newer when --setuid is used. Get it at http://www.python.org.
+Python 2.5 or newer, Python 2.6 or newer when --ssl-pem-file is used.
+Get it at http://www.python.org.
 
 Installation
 ------------

--- a/miniircd
+++ b/miniircd
@@ -757,8 +757,8 @@ class Server(object):
             os.chroot(self.chroot)
             self.print_info("Changed root directory to %s" % self.chroot)
         if self.setuid:
-            os.setresgid(self.setuid[1], self.setuid[1], self.setuid[1])
-            os.setresuid(self.setuid[0], self.setuid[0], self.setuid[0])
+            os.setgid(self.setuid[1])
+            os.setuid(self.setuid[0])
             self.print_info("Setting uid:gid to %s:%s"
                             % (self.setuid[0], self.setuid[1]))
         last_aliveness_check = time.time()


### PR DESCRIPTION
Please refer to the OS syscall documentation: when used by root, set[gu]id
does exactly the same thing that the more verbose setres[gu]id was thought
necessary for.  It wasn't.
