### PR TITLE
Name list message too long

### DIFF
--- a/miniircd
+++ b/miniircd
@@ -268,17 +268,21 @@ class Client(object):
                     self.reply("331 %s %s :No topic is set"
                                % (self.nickname, channel.name))
                 names_prefix = "353 %s = %s :" % (self.nickname, channelname)
-                names = names_prefix
-                # max length: reply prefix ":server_name(space)" plus CRLF in the end
+                names = ''
+                # max length: reply prefix ":server_name(space)"
+                # plus CRLF in the end
                 names_max_len = 512 - (len(self.server.name) + 2 + 2)
                 for name in sorted(x.nickname for x in channel.members):
+                    if not names:
+                        names = names_prefix + name
                     # using >= to include the space between "names" and "name"
-                    if len(names) + len(name) >= names_max_len:
+                    elif len(names) + len(name) >= names_max_len:
                         self.reply(names)
                         names = names_prefix + name
                     else:
                         names += ' ' + name
-                self.reply(names)
+                if names:
+                    self.reply(names)
                 self.reply("366 %s %s :End of NAMES list"
                            % (self.nickname, channelname))
 

--- a/miniircd
+++ b/miniircd
@@ -267,11 +267,16 @@ class Client(object):
                 else:
                     self.reply("331 %s %s :No topic is set"
                                % (self.nickname, channel.name))
-                self.reply("353 %s = %s :%s"
-                           % (self.nickname,
-                              channelname,
-                              " ".join(sorted(x.nickname
-                                              for x in channel.members))))
+                names_prefix = "353 %s = %s :" % (self.nickname, channelname)
+                names = names_prefix
+                for name in sorted(x.nickname for x in channel.members):
+                    # 510 + space + CRLF = 512 as per RFC
+                    if len(names) + len(name) > 509:
+                        self.reply(names)
+                        names = names_prefix + name
+                    else:
+                        names += ' ' + name
+                self.reply(names)
                 self.reply("366 %s %s :End of NAMES list"
                            % (self.nickname, channelname))
 

--- a/miniircd
+++ b/miniircd
@@ -269,9 +269,11 @@ class Client(object):
                                % (self.nickname, channel.name))
                 names_prefix = "353 %s = %s :" % (self.nickname, channelname)
                 names = names_prefix
+                # max length: reply prefix ":server_name(space)" plus CRLF in the end
+                names_max_len = 512 - (len(self.server.name) + 2 + 2)
                 for name in sorted(x.nickname for x in channel.members):
-                    # 510 + space + CRLF = 512 as per RFC
-                    if len(names) + len(name) > 509:
+                    # using >= to include the space between "names" and "name"
+                    if len(names) + len(name) >= names_max_len:
                         self.reply(names)
                         names = names_prefix + name
                     else:

--- a/test.py
+++ b/test.py
@@ -243,6 +243,60 @@ class TestBasicStuff(ServerFixture):
         self.expect("lemur", r":lemur!lemur@127.0.0.1 PART #fisk :boa")
         self.expect("apa", r":lemur!lemur@127.0.0.1 PART #fisk :boa")
 
+    def test_join_and_name_many_users(self):
+        base_nick = 'A' * 49
+        # :FQDN 353 nick = #fisk :
+        base_len = len(socket.getfqdn()) + 66
+
+        one_line = (512 - base_len) / 50
+        nick_list_one = []
+        for i in range(one_line):
+            long_nick = '%s%d' % (base_nick, i)
+            nick_list_one.append(long_nick)
+            self.connect(long_nick)
+            self.send(long_nick, "JOIN #fisk")
+            self.expect(
+                long_nick,
+                r":%(nick)s!%(nick)s@127.0.0.1 JOIN #fisk" % {
+                    'nick': long_nick
+                }
+            )
+            self.expect(long_nick, r":local\S+ 331 %s #fisk :.*" % long_nick)
+            self.expect(
+                long_nick,
+                r":local\S+ 353 %s = #fisk :%s" % (
+                    long_nick, ' '.join(nick_list_one)
+                )
+            )
+            self.expect(long_nick, r":local\S+ 366 %s #fisk :.*" % long_nick)
+
+        nick_list_two = []
+        for i in range(10 - one_line):
+            long_nick = '%s%d' % (base_nick, one_line + i)
+            nick_list_two.append(long_nick)
+            self.connect(long_nick)
+            self.send(long_nick, "JOIN #fisk")
+            self.expect(
+                long_nick,
+                r":%(nick)s!%(nick)s@127.0.0.1 JOIN #fisk" % {
+                    'nick': long_nick
+                }
+            )
+            self.expect(long_nick, r":local\S+ 331 %s #fisk :.*" % long_nick)
+            self.expect(
+                long_nick,
+                r":local\S+ 353 %s = #fisk :%s" % (
+                    long_nick, ' '.join(nick_list_one)
+                )
+            )
+            self.expect(
+                long_nick,
+                r":local\S+ 353 %s = #fisk :%s" % (
+                    long_nick, ' '.join(nick_list_two)
+                )
+            )
+            self.expect(long_nick, r":local\S+ 366 %s #fisk :.*" % long_nick)
+
     def test_ison(self):
         self.connect("apa")
         self.send("apa", "ISON apa lemur")


### PR DESCRIPTION
Split name list messages as per RFC maximum message length of 512 characters.