### PR TITLE
Remove unnecessary colon from RPL_MYINFO

### DIFF
--- a/miniircd
+++ b/miniircd
@@ -212,7 +212,7 @@ class Client(object):
                        % (self.nickname, server.name, VERSION))
             self.reply("003 %s :This server was created sometime"
                        % self.nickname)
-            self.reply("004 %s :%s miniircd-%s o o"
+            self.reply("004 %s %s miniircd-%s o o"
                        % (self.nickname, server.name, VERSION))
             self.send_lusers()
             self.send_motd()


### PR DESCRIPTION
The inclusion of a colon turns the server name, version, and available modes info into a single parameter. This can result in improper parsing by IRC clients.

Here's an example RPL_MYINFO from a charybdis server:
`:nova.esper.net 004 TestNickHere nova.esper.net charybdis-3.5.3 DQRSZagiloswz CFILPQTbcefgijklmnopqrstvz bkloveqjfI`

Here's some other IRCd source code that shows the colon is incorrect:
* [ElementalIRCd](https://github.com/Elemental-IRCd/elemental-ircd/blob/13d70b39699f7255120e8fb1e860dbef87443008/src/messages.tab#L24-L25)
* [ircd-hybrid](https://github.com/ircd-hybrid/ircd-hybrid/blob/84c5bf581230fc8f3082c1f64239dfa5289f2488/src/numeric.c#L35-L36)
* [Nefarious IRCu](https://github.com/evilnet/nefarious2/blob/e42fbfba88c848f3d6def71ae3be6d25f7b063e8/ircd/s_err.c#L40-L43)