### PR TITLE
Correct WHOIS 319 to the RFC standard

### DIFF
--- a/miniircd
+++ b/miniircd
@@ -551,7 +551,7 @@ class Client(object):
                               server.name))
                 self.reply("319 %s %s :%s"
                            % (self.nickname, user.nickname,
-                              " ".join(user.channels)))
+                              "".join([channel + " " for channel in user.channels])))
                 self.reply("318 %s %s :End of WHOIS list"
                            % (self.nickname, user.nickname))
             else:


### PR DESCRIPTION
WHOIS 319 is the channel list, it requires a space after every channel which includes the end.
As seen in:
 - https://www.alien.net.au/irc/irc2numerics.html
 - https://www.ietf.org/rfc/rfc1459.txt
Control+F "319"