### PR TITLE
Add __name__ check

### DIFF
--- a/miniircd
+++ b/miniircd
@@ -1067,5 +1067,5 @@ def main(argv):
     except KeyboardInterrupt:
         server.print_error("Interrupted.")
 
-
-main(sys.argv)
+if __name__ == "__main__":
+    main(sys.argv)


### PR DESCRIPTION
Adding __name__ check to allow importing of miniircd as a module (without executing main() function).

This is helpful, because my project spawns multiple different IRC "virtual hosts" from a python script like that:

    import miniircd
    multiprocessing.Process(target=miniircd.main, args=(['./miniircd.py', '--ports=10001'],),).start()
    multiprocessing.Process(target=miniircd.main, args=(['./miniircd.py', '--ports=10002'],),).start()
    multiprocessing.Process(target=miniircd.main, args=(['./miniircd.py', '--ports=10003'],),).start()

etc.