### PR TITLE
Pidfile py3 compat + auto deletion on shutdown

### DIFF
--- a/miniircd
+++ b/miniircd
@@ -741,6 +741,12 @@ class Server(object):
             self.print_error("Could not create PID file %r" % filename)
             sys.exit(1)
 
+    def remove_pid_file(self, filename):
+        try:
+            os.remove(filename)
+        except:
+            self.print_error("Could not remove PID file %r" % filename)
+
     def daemonize(self):
         try:
             pid = os.fork()
@@ -1073,6 +1079,9 @@ def main(argv):
         server.start()
     except KeyboardInterrupt:
         server.print_error("Interrupted.")
+    finally:
+        if options.pid_file:
+            server.remove_pid_file(options.pid_file)
 
 
 if __name__ == "__main__":

--- a/miniircd
+++ b/miniircd
@@ -735,7 +735,7 @@ class Server(object):
     def make_pid_file(self, filename):
         try:
             fd = os.open(filename, os.O_RDWR | os.O_CREAT | os.O_EXCL, 0o644)
-            os.write(fd, "%i\n" % os.getpid())
+            os.write(fd, b"%i\n" % os.getpid())
             os.close(fd)
         except:
             self.print_error("Could not create PID file %r" % filename)


### PR DESCRIPTION
Hello,

I had two problems with the pidfile, here are two commits that each address the issues I had.

I'm running miniircd using python3 and I had trouble setting a pidfile. Somehow, the `os.write` function is different between py2 and py3, py3 requires a bytes-like object whereas py2 is fine with both str and bytes.

Also the process doesn't remove the said pidfile on shutdown, I don't know if it is normal to let orphaned pidfile on the file system and it was preventing me from re-starting the server due to the `O_EXCL` flag at https://github.com/jrosdahl/miniircd/blob/c83ce1b15e89ee793f1ffbca154b3e31537545c1/miniircd#L737 as the file was not automatically removed.

Thank you :)