### PR TITLE
Fix `--help` option

### DIFF
--- a/miniircd
+++ b/miniircd
@@ -1085,7 +1085,7 @@ def main(argv: Sequence[str]) -> None:
         metavar="X",
         default=10,
         type=int,
-        help="keep X log files; default: %default",
+        help="keep X log files; default: %(default)s",
     )
     ap.add_argument("--log-file", metavar="X", help="store log in file X")
     ap.add_argument(
@@ -1093,7 +1093,7 @@ def main(argv: Sequence[str]) -> None:
         metavar="X",
         default=10,
         type=int,
-        help="set maximum log file size to X MiB; default: %default MiB",
+        help="set maximum log file size to X MiB; default: %(default)s MiB",
     )
     ap.add_argument(
         "--motd", metavar="X", help="display file X as message of the day"


### PR DESCRIPTION
argparse supports `%`-formatting in help string and to use a literal
`%` it should be escaped via `%%`.

The non-escaped `%` used accidentally broke `--help` option after the
migration to argparse, e.g. (on Python 3.8.5):

```
% ./miniircd --help
Traceback (most recent call last):
  File "./miniircd", line 1226, in <module>
    main(sys.argv)
[...]
  File "/usr/pkg/lib/python3.8/argparse.py", line 529, in _format_action
    help_text = self._expand_help(action)
  File "/usr/pkg/lib/python3.8/argparse.py", line 621, in _expand_help
    return self._get_help_string(action) % params
TypeError: %d format: a number is required, not dict
```

This pull request just escape all occurences of `%` in help strings so
`miniircd --help` works again.