### PR TITLE
Fix stats file update on Windows

### DIFF
--- a/miniircd
+++ b/miniircd
@@ -108,6 +108,7 @@ class Channel:
         fp.write("topic = %r\n" % self.topic)
         fp.write("key = %r\n" % self.key)
         fp.close()
+        os.remove(self._state_path)
         os.rename(path, self._state_path)
 
 

--- a/miniircd
+++ b/miniircd
@@ -108,8 +108,7 @@ class Channel:
         fp.write("topic = %r\n" % self.topic)
         fp.write("key = %r\n" % self.key)
         fp.close()
-        os.remove(self._state_path)
-        os.rename(path, self._state_path)
+        os.replace(path, self._state_path)
 
 
 class Client:


### PR DESCRIPTION
Possible resolution for #49. Deletes the old state file before renaming the tmp state file.